### PR TITLE
Use UTC system time in jest fake timers

### DIFF
--- a/orders/src/services/__tests__/orders.db.service.spec.ts
+++ b/orders/src/services/__tests__/orders.db.service.spec.ts
@@ -5,7 +5,7 @@ import { awsSdkGetPromiseResponse } from "../../__mocks__/aws-sdk";
 describe("orders.db.service", () => {
   beforeAll(() => {
     jest.useFakeTimers("modern");
-    jest.setSystemTime(new Date(2022, 1, 28));
+    jest.setSystemTime(Date.UTC(2022, 1, 28));
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Problem
When calling new Date() without parameters, it creates a date object in your local timezone, but toISOString() always converts this to UTC (Coordinated Universal Time)

Central European Time during winter return 1 hour earlier than local time UTC+1

<img width="666" alt="image" src="https://github.com/user-attachments/assets/1c35fb00-4513-414a-b97c-adf7c0087ee0">


## Solution
Modified tests to explicitly use UTC timezone to ensure consistent behavior across different environments.

## Testing Done
- Ran tests in different timezone settings
- Verified test passes consistently